### PR TITLE
Use python-config-wrapper from radare2-bindings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ lang_python.${EXT_SO}:
 	$(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --cflags --libs r_reg r_core r_cons) \
 	${LDFLAGS_LIB} -o lang_python.${EXT_SO} python.c -lpython37
 else
-PYCFLAGS=$(shell python-config --includes) -DPYVER=3
-PYLDFLAGS=$(shell python-config --libs)
-PYLDFLAGS+=-L$(shell python-config --prefix)/lib
+PYCFLAGS=$(shell PYVER=3 ./python-config-wrapper --includes) -DPYVER=3
+PYLDFLAGS=$(shell PYVER=3 ./python-config-wrapper --libs)
+PYLDFLAGS+=-L$(shell PYVER=3 ./python-config-wrapper --prefix)/lib
 PYLDFLAGS+=${LDFLAGS_LIB}
 
 lang_python.$(EXT_SO):

--- a/python-config-wrapper
+++ b/python-config-wrapper
@@ -1,0 +1,36 @@
+#!/bin/sh
+# python-config wrapper trying to fix the python versioning hell
+# -- pancake
+
+PCS="${PYTHON_CONFIG}
+	python3-config
+	python38-config
+	python3.8-config
+	python37-config
+	python3.7-config
+	python36-config
+	python3.6-config
+	python-config"
+
+PYCFG=""
+
+for a in ${PCS} ; do
+	$a --help >/dev/null 2>&1
+	if [ $? = 0 ]; then
+		PYCFG=$a
+		break
+	fi
+done
+
+[ -z "${PYCFG}" ] && exit 1
+if [ "$1" = "-n" ]; then
+	echo "${PYCFG}"
+	exit 0
+fi
+
+"${PYCFG}" "$@" | sed \
+	-e 's/-arch [^\ ]*//g' \
+	-e 's, s ,,g' \
+	-e 's,-mn[^\ ]*,,g' \
+	-e 's,-fn[^\ ]*,,g' \
+	-e 's,-Wstrict-prototypes,,g' 2>/dev/null


### PR DESCRIPTION
Required to support building on systems where Python 2 is still installed (as python-config points to the Python 2 version).