### PR TITLE
Use the mnemonic field in RAnalOp to avoid warnings in r2

### DIFF
--- a/python/anal.c
+++ b/python/anal.c
@@ -201,6 +201,7 @@ static int py_anal(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RA
 				READ_VAL(tmpdst, op->dst, tmpreg)
 				// Loading 'var' value if presented
 				r_strbuf_set (&op->esil, getS (dict, "esil"));
+				op->mnemonic = r_str_new (getS (dict, "mnemonic"));
 				// TODO: Add opex support here
 				Py_DECREF (dict);
 			}


### PR DESCRIPTION
Recent changes in r2 require the `mnemonic` field in `RAnalOp` structs to be populated - otherwise, warnings are displayed for each decoded opcode on screen. This PR adds support for populating the field in Python plugins.