### PR TITLE
Introduce endianness PyEnums

### DIFF
--- a/python.c
+++ b/python.c
@@ -204,6 +204,7 @@ static PyObject *init_radare_module(void) {
 	}
 	RadareType.tp_dict = PyDict_New();
 	py_export_anal_enum(RadareType.tp_dict);
+	py_export_asm_enum(RadareType.tp_dict);
 	PyObject *m = PyModule_Create (&EmbModule);
 	if (!m) {
 		eprintf ("Cannot create python3 r2 module\n");

--- a/python/asm.c
+++ b/python/asm.c
@@ -3,6 +3,24 @@
 #include "asm.h"
 #include "core.h"
 
+void py_export_asm_enum(PyObject *tp_dict) {
+
+#define PYENUM(name) {\
+		PyObject *o = PyLong_FromLong(name); \
+		if (o) { \
+			PyDict_SetItemString(tp_dict, #name, o); \
+			Py_DECREF(o); \
+		}\
+	}
+
+	// R_SYS_ENDIAN_*
+	PYENUM(R_SYS_ENDIAN_NONE);
+	PYENUM(R_SYS_ENDIAN_LITTLE);
+	PYENUM(R_SYS_ENDIAN_BIG);
+	PYENUM(R_SYS_ENDIAN_BI);
+#undef PYENUM
+}
+
 /* TODO : move into a struct stored in the plugin struct */
 static void *py_assemble_cb = NULL;
 static void *py_disassemble_cb = NULL;

--- a/python/asm.h
+++ b/python/asm.h
@@ -6,6 +6,8 @@
 #include <r_asm.h>
 #include "common.h"
 
+void py_export_asm_enum(PyObject *tp_dict);
+
 void Radare_plugin_asm_free(RAsmPlugin *ap);
 
 PyObject *Radare_plugin_asm(Radare* self, PyObject *args);


### PR DESCRIPTION
While updating a Python plugin I wrote I've discovered that the `endian` field no longer accepts strings, but integers, presumably the same kind as the `R_SYS_ENDIAN_*` ones used elsewhere in the codebase. This PR allows using a value like `R.R_SYS_ENDIAN_BIG` instead. Things left to do:

- [ ] Test whether it actually works (I have no idea how to retrieve that information for a plugin)
- [ ] Adjust the documentation on https://radare.gitbooks.io/radare2book/content/plugins/python.html (once this PR has been merged)