### PR TITLE
Try `python-config --libs --embed` first.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ lang_python.${EXT_SO}:
 	${LDFLAGS_LIB} -o lang_python.${EXT_SO} python.c -lpython37
 else
 PYCFLAGS=$(shell PYVER=3 ./python-config-wrapper --includes) -DPYVER=3
-PYLDFLAGS=$(shell PYVER=3 ./python-config-wrapper --libs)
+# Python3.8+ requires new `--embed` flag to include `-lpython`. 
+PYLDFLAGS=$(shell PYVER=3 ./python-config-wrapper --libs --embed || \
+                  PYVER=3 ./python-config-wrapper --libs)
 PYLDFLAGS+=-L$(shell PYVER=3 ./python-config-wrapper --prefix)/lib
 PYLDFLAGS+=${LDFLAGS_LIB}
 

--- a/python-config-wrapper
+++ b/python-config-wrapper
@@ -28,7 +28,8 @@ if [ "$1" = "-n" ]; then
 	exit 0
 fi
 
-"${PYCFG}" "$@" | sed \
+output=`"${PYCFG}" "$@"` \
+      && echo $output || echo $output 1>&2 | sed \
 	-e 's/-arch [^\ ]*//g' \
 	-e 's, s ,,g' \
 	-e 's,-mn[^\ ]*,,g' \


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**
https://github.com/radareorg/radare2-rlang/issues/12

**Test plan**
I tested `make` on Ubuntu 20.04 (python3.8) and Debian 10 (python3.7).

`r2 -q -c '#!' -` includes `python` in both. Previously radare started without error, but python plugin was missing in Ubuntu 20.04.

**Closing issues**
closes #12 

