### PR TITLE
Not all systems have the right libraries in `<prefix>/lib`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ PYCFLAGS=$(shell PYVER=3 ./python-config-wrapper --includes) -DPYVER=3
 # Python3.8+ requires new `--embed` flag to include `-lpython`. 
 PYLDFLAGS=$(shell PYVER=3 ./python-config-wrapper --libs --embed || \
                   PYVER=3 ./python-config-wrapper --libs)
-PYLDFLAGS+=-L$(shell PYVER=3 ./python-config-wrapper --prefix)/lib
+PYLDFLAGS+=$(shell PYVER=3 ./python-config-wrapper --ldflags)
 PYLDFLAGS+=${LDFLAGS_LIB}
 
 lang_python.$(EXT_SO):

--- a/python/core.h
+++ b/python/core.h
@@ -6,7 +6,7 @@
 #include <r_core.h>
 #include "common.h"
 
-RCore *core;
+extern RCore *core;
 
 void Radare_plugin_core_free(RCorePlugin *ap);
 


### PR DESCRIPTION
Some use /usr/lib64 and providing -L/usr/lib would confuse the linker.

<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The Makefile assumes that libraries are in `<prefix>/lib` (e.g. `/usr/lib`) but some systems use `/usr/lib64` for 64bit libraries and `/usr/lib` for 32 bit ones. Thus adding `-L/usr/lib` confuses the linker, as it now finds the 32bit version of libc instead of the right one

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

On a Fedora 31 system try to compile python lang with `make py`.
I get the following output before applying this patch:
```
/usr/bin/ld: skipping incompatible /usr/lib/libc.so when searching for -lc
```
It should probably be tested on multiple platforms...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None.