### PR TITLE
Adding support for more RAnalOp fields to Python arch plugin

### DIFF
--- a/python/examples/test-py-arch.py
+++ b/python/examples/test-py-arch.py
@@ -52,28 +52,31 @@ def pyarch(a):
 			},
 			1: {
 				"op": {
-					"mnemonic" : "mov",
-					"type" : R.R_ANAL_OP_TYPE_MOV,
+					"mnemonic" : "mov r{}, #0x{:02x}".format(buf[1], buf[2]),
+					"type" : R.R_ANAL_OP_TYPE_MOV,					
 					"cycles" : 2,
+					"val" : buf[2],
 					},
 				"size": 3
 			},
 			2: {
 				"op": {
-					"mnemonic" : "fadd",
+					"mnemonic" : "fadd r{}, ${}".format(buf[1], buf[2]),
 					"type" : R.R_ANAL_OP_TYPE_ADD,
 					"family" : R.R_ANAL_OP_FAMILY_FPU,
 					"cycles" : 2,
+					"ptr" : buf[2],
 				},
 				"size": 3
 			},
 			3: {
 				"op": {
-					"mnemonic" : "jne",
+					"mnemonic" : "jne 0x{:04x}".format((buf[1] << 8) | buf[2]),
 					"type" : R.R_ANAL_OP_TYPE_CJMP,
 					"cycles" : 2,
 					"jump" : (buf[1] << 8) | buf[2],
 					"fail" : pc+3,
+					"cond" : R.R_ANAL_COND_NE,
 					"eob" : True
 				},
 				"size": 3

--- a/python/python/arch.c
+++ b/python/python/arch.c
@@ -231,13 +231,28 @@ static bool py_arch_decode(RArchSession *as, RAnalOp *op, RAnalOpMask mask) {
 				if (len && dict) {
 					if (PyDict_Check (dict)) {
 						op->size = PyNumber_AsSsize_t (len, NULL);
-						op->mnemonic = strdup (getS (dict, "mnemonic"));
-						op->family = (getI (dict, "family"));
-						op->cycles = (getI (dict, "cycles"));
-						op->type = (getI (dict, "type"));
-						op->jump = (getI (dict, "jump"));
-						op->fail = (getI (dict, "fail"));
-						op->eob = (getB (dict, "eob"));
+						if (contains (dict, "mnemonic"))
+							op->mnemonic = strdup (getS (dict, "mnemonic"));
+						if (contains (dict, "familiy"))
+							op->family = (getI (dict, "family"));
+						if (contains (dict, "cycles"))
+							op->cycles = (getI (dict, "cycles"));
+						if (contains (dict, "type"))
+							op->type = (getI (dict, "type"));
+						if (contains (dict, "cond"))
+							op->cond = (getI (dict, "cond"));
+						if (contains (dict, "jump"))
+							op->jump = (getI (dict, "jump"));
+						if (contains (dict, "fails"))
+							op->fail = (getI (dict, "fail"));		
+						if (contains (dict, "eob"))
+							op->eob = (getB (dict, "eob"));
+						if (contains (dict, "ptr"))
+							op->ptr = (getI (dict, "ptr"));
+						if (contains (dict, "ptrsize"))
+							op->ptrsize = (getI (dict, "ptrsize"));
+						if (contains (dict, "val"))
+							op->val = (getI (dict, "val"));
 						res = true;
 					}
 				}

--- a/python/python/arch.c
+++ b/python/python/arch.c
@@ -243,7 +243,7 @@ static bool py_arch_decode(RArchSession *as, RAnalOp *op, RAnalOpMask mask) {
 							op->cond = (getI (dict, "cond"));
 						if (contains (dict, "jump"))
 							op->jump = (getI (dict, "jump"));
-						if (contains (dict, "fails"))
+						if (contains (dict, "fail"))
 							op->fail = (getI (dict, "fail"));		
 						if (contains (dict, "eob"))
 							op->eob = (getB (dict, "eob"));

--- a/python/python/common.c
+++ b/python/python/common.c
@@ -4,8 +4,8 @@
 
 bool contains(PyObject *o, const char *name) {
 	if (!o || !name) return false;	
-	PyObject *str = PyUnicode_FromString(name);
-	return (PyDict_Contains(o, str) == 1);
+	PyObject *str = PyUnicode_FromString (name);
+	return (PyDict_Contains (o, str) == 1);
 }
 
 PyObject *getO(PyObject *o, const char *name) {
@@ -36,6 +36,6 @@ void *getF(PyObject *o, const char *name) {
 
 bool getB(PyObject *o, const char *name) {
 	if (!o || o == Py_None) return NULL;
-	if (PyObject_IsTrue(o)) return true;
+	if (PyObject_IsTrue (o)) return true;
 	return false;
 }

--- a/python/python/common.c
+++ b/python/python/common.c
@@ -2,6 +2,12 @@
 
 #include "common.h"
 
+bool contains(PyObject *o, const char *name) {
+	if (!o || !name) return false;	
+	PyObject *str = PyUnicode_FromString(name);
+	return (PyDict_Contains(o, str) == 1);
+}
+
 PyObject *getO(PyObject *o, const char *name) {
 	if (!o) return NULL;
 	PyObject *res = PyDict_GetItemString (o, name);

--- a/python/python/common.h
+++ b/python/python/common.h
@@ -26,6 +26,8 @@ typedef struct {
 	int number;
 } Radare;
 
+bool contains(PyObject *o, const char *name);
+
 PyObject *getO(PyObject *o, const char *name);
 
 char *getS(PyObject *o, const char *name);


### PR DESCRIPTION
Added support for the following fields of RAnalOp to decode function:
- ptr
- ptrsize
- val
- cond

Expanded example to cover these.
