### PR TITLE
added most of RAnalOp fields for decode

### DIFF
--- a/python/examples/test-py-arch.py
+++ b/python/examples/test-py-arch.py
@@ -41,7 +41,6 @@ def pyarch(a):
 			return res
 
 	def decode(buf, pc):
-		print(pc, len(buf))
 		ops = {
 			0: {
 				"op": {

--- a/python/examples/test-py-arch.py
+++ b/python/examples/test-py-arch.py
@@ -41,6 +41,7 @@ def pyarch(a):
 			return res
 
 	def decode(buf, pc):
+		print(pc, len(buf))
 		ops = {
 			0: {
 				"op": {
@@ -52,20 +53,21 @@ def pyarch(a):
 			},
 			1: {
 				"op": {
-					"mnemonic" : "mov r{}, #0x{:02x}".format(buf[1], buf[2]),
-					"type" : R.R_ANAL_OP_TYPE_MOV,					
+					"mnemonic" : "mov r{}, 0x{:02x}".format(buf[1], buf[2]),
+					"type" : R.R_ANAL_OP_TYPE_MOV,
 					"cycles" : 2,
-					"val" : buf[2],
+					"ptr" : buf[2],
+					"direction" : R.R_ANAL_OP_DIR_READ,
 					},
 				"size": 3
 			},
 			2: {
 				"op": {
-					"mnemonic" : "fadd r{}, ${}".format(buf[1], buf[2]),
+					"mnemonic" : "fadd r{}, #0x{:02x}".format(buf[1], buf[2]),
 					"type" : R.R_ANAL_OP_TYPE_ADD,
 					"family" : R.R_ANAL_OP_FAMILY_FPU,
 					"cycles" : 2,
-					"ptr" : buf[2],
+					"val" : buf[2],
 				},
 				"size": 3
 			},


### PR DESCRIPTION
Went through RAnalOp and added most of the fields for decode.

Still missing are more complex fields like srcs, dsts, switch_op, etc.

Also added some error checking, so that it's easier to catch errors in the Python plugin, e.g. typos in field names.

